### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Unified Context Layer (UCL) is a multi-tenant Model Context Protocol (MCP) server that enables AI agents, automation platforms, and applications to connect to over 1,000 SaaS tools—such as Slack, Jira, Gmail, Shopify, Notion, and more—via a single standardized /command endpoint. UCL abstracts away SDK sprawl, glue code, and complex authentication flows, allowing developers to orchestrate context-rich, cross-platform integrations without building and maintaining separate connectors for each service.
 
+<a href="https://glama.ai/mcp/servers/@fastnai/mcp-fastn">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@fastnai/mcp-fastn/badge" alt="Fastn Server MCP server" />
+</a>
+
 ## Features
 
 - **Integrated platform support** - Use services like Slack, Notion, HubSpot, and more through the Fastn server


### PR DESCRIPTION
This PR adds a badge for the [Fastn Server](https://glama.ai/mcp/servers/@fastnai/mcp-fastn) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@fastnai/mcp-fastn">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@fastnai/mcp-fastn/badge" alt="Fastn Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.